### PR TITLE
change format of configs

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,23 +1,33 @@
 
 ### INPUT
-ABC_BIOSAMPLES: "config/config_biosamples.tsv"
+# choose a set of the following options: "run_ABC", "features_genomewide", "features_CRISPR", "predict_genomewide"
+# genomewide features are always calculated, so dataset_config always requires columns: dataset, feature_table
+#   ABC_directory also required UNLESS "run_ABC" is also selected
+# if "run_ABC" is selected: must also include config columns required by ABC and specifg ABC_DIR_PATH below 
+#   new ABC directories will replace anything specified by the user in dataset_config
+# if "features_CRISPR" is selected: no additional columns in dataset_config are required, but crispr_dataset below must be!
+# if "predict_genomewide" is selected: dataset_config also requires a columns: trained_model, threshold
+
+steps: ["features_CRISPR"] # options: "run_ABC", "features_genomewide", "features_CRISPR", "predict_genomewide"
+
+
+# TO DO: integrate input config files (keep track of which columns are necessary for which steps)
+# ABC_BIOSAMPLES: "config/config_biosamples.tsv" # if "run_ABC" 
+dataset_config: "config/dataset_config_ATAC.tsv" # dataset / ABC_directory / feature_table (when you already have ABC)
 
 ### OUTPUT
-results_dir: "results/"
+results_dir: "2023_1114_ATAC_Xu/"
 
-### PARAMS
-ABC_DIR_PATH: "ABC"
-
-### Reference Files
+### REFERENCE
 gene_TSS500: "resources/RefSeqCurated.170308.bed.CollapsedGeneBounds.hg38.TSS500bp.bed"
 chr_sizes: "resources/GRCh38_EBV.no_alt.chrom.sizes.tsv"
 ubiq_expr_genes: "resources/for_classifier_use_ubiquitous_expression_RefSeqCurated.170308.bed.CollapsedGeneBounds.hg38.TSS500bp.txt"
-
-# Filling new features into prediction file
-feature_config: "config/feature_config.tsv"
 crispr_dataset: "resources/EPCrisprBenchmark_ensemble_data_GRCh38.tsv.gz"
 
-# ENCODE E2G
+### PARAMS - what is this?
+ABC_DIR_PATH: "ABC"
+
+# ENCODE E2G - edit later
 feature_table: 
   ATAC: "/oak/stanford/groups/engreitz/Users/sheth/ENCODE-E2G_v2/data/feature_table/model_scATAC_IGVF.tsv"
   DHS: "/oak/stanford/groups/engreitz/Users/atan5133/ENCODE-E2G/data/feature_table/model_ablation_encode_e2g.tsv"

--- a/config/dataset_config_test.tsv
+++ b/config/dataset_config_test.tsv
@@ -1,0 +1,4 @@
+dataset	ABC_directory	feature_table	biosample	DHS	ATAC	H3K27ac	default_accessibility_feature	HiC_dir	HiC_type	HiC_resolution	HiC_gamma	HiC_scale	alt_TSS	alt_genes	trained_model	threshold
+DNase_powerlaw	/oak/stanford/groups/engreitz/Users/atan5133/abc_run_comparisons/results_dev_11_09_dhs_only_avg_hic	/oak/stanford/groups/engreitz/Users/sheth/encode_e2g_features/config/feature_config_DNase_powerlaw.tsv														
+DNase_avghic	/oak/stanford/groups/engreitz/Users/atan5133/abc_run_comparisons/results_dev_11_09_dhs_only_avg_hic	/oak/stanford/groups/engreitz/Users/sheth/encode_e2g_features/config/feature_config_DNase_hic.tsv														
+DNase_megamap	/oak/stanford/groups/engreitz/Users/atan5133/abc_run_comparisons/results_dev_11_10_dhs_only_megamap	/oak/stanford/groups/engreitz/Users/sheth/encode_e2g_features/config/feature_config_DNase_hic.tsv														

--- a/config/feature_config_DNase_hic.tsv
+++ b/config/feature_config_DNase_hic.tsv
@@ -1,0 +1,14 @@
+feature	input_col	square_source_col	aggregate_function	fill_value
+numTSSEnhGene	numTSSEnhGene	NA	max	0
+distanceToTSS	distance	NA	min	NA
+normalizedDNase_enh	normalized_dhs	NA	mean	0
+normalizedDNase_prom	normalized_dhs_b	NA	mean	0
+numNearbyEnhancers	numNearbyEnhancers	NA	max	0
+sumNearbyEnhancers	sumNearbyEnhancers	NA	max	0
+ubiquitousExpressedGene	is_ubiqutious_uniform	NA	max	0
+numCandidateEnhGene	numCandidateEnhGene	NA	max	0
+3DContact	hic_contact_pl_scaled_adj	NA	mean	0
+3DContact_squared	hic_contact_pl_scaled_adj_squared	hic_contact_pl_scaled_adj	mean	0
+normalizedDNase_enh_squared	normalized_dhs_squared	normalized_dhs	mean	0
+TargetGenePromoterActivityQuantile	TargetGenePromoterActivityQuantile	NA	mean	0
+ABC.Score	ABC.Score	NA	sum	0

--- a/config/feature_config_DNase_powerlaw.tsv
+++ b/config/feature_config_DNase_powerlaw.tsv
@@ -1,0 +1,14 @@
+feature	input_col	square_source_col	aggregate_function	fill_value
+numTSSEnhGene	numTSSEnhGene	NA	max	0
+distanceToTSS	distance	NA	min	NA
+normalizedDNase_enh	normalized_dhs	NA	mean	0
+normalizedDNase_prom	normalized_dhs_b	NA	mean	0
+numNearbyEnhancers	numNearbyEnhancers	NA	max	0
+sumNearbyEnhancers	sumNearbyEnhancers	NA	max	0
+ubiquitousExpressedGene	is_ubiqutious_uniform	NA	max	0
+numCandidateEnhGene	numCandidateEnhGene	NA	max	0
+powerLawContact	powerlaw_contact	NA	mean	0
+powerLawContact_squared	powerlaw_contact_squared	powerlaw_contact	mean	0
+normalizedDNase_enh_squared	normalized_dhs_squared	normalized_dhs	mean	0
+TargetGenePromoterActivityQuantile	TargetGenePromoterActivityQuantile	NA	mean	0
+ABC.Score	powerlaw.Score	NA	sum	0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -9,49 +9,62 @@ import yaml
 configfile: "config/config.yml"
 conda: "mamba"
 
+## Process config file ["run_ABC", "features_CRISPR", "predict_genomewide"]
+# run_ABC requires ABC parameters and produces ABC directory
+# features_CRISPR requires ABC directory & feature table and produces new features on top of ABC and merged to CRISPR data
+# predict_genomewide requires ABC directory, feature table, and pretrained model and produces new features on top of ABC & E2G predictions
+
+STEPS = config["steps"]
 RESULTS_DIR = config["results_dir"]
+DATASET_DF = pd.read_csv(config["dataset_config"], sep="\t").set_index("dataset", drop=False)
+SAMPLES = list(DATASET_DF.index.values)
 
-def get_abc_config(config):
-	abc_config_file = os.path.join(config["ABC_DIR_PATH"], "config/config.yaml")
-	with open(abc_config_file, 'r') as stream:
-		abc_config = yaml.safe_load(stream)
-	abc_config["ABC_DIR_PATH"] = config["ABC_DIR_PATH"]
-	abc_config["biosamplesTable"] = config["ABC_BIOSAMPLES"]
-	return abc_config
+# always calculate genome-wide feature tables
+OUTPUT_FILES = []
+OUTPUT_FILES.extend(expand(os.path.join(RESULTS_DIR, "{biosample}", "ActivityOnly_features.tsv.gz"), biosample=SAMPLES))
 
+if ("run_ABC" in STEPS):
+	##  ABC module
+	def get_abc_config(config):
+		abc_config_file = os.path.join(config["ABC_DIR_PATH"], "config/config.yaml")
+		with open(abc_config_file, 'r') as stream:
+			abc_config = yaml.safe_load(stream)
+		abc_config["ABC_DIR_PATH"] = config["ABC_DIR_PATH"]
+		abc_config["biosamplesTable"] = config["ABC_BIOSAMPLES"]
+		return abc_config
 
-module ABC:
-    snakefile:
-        "../ABC/workflow/Snakefile"
-    config: get_abc_config(config)
+	module ABC:
+		snakefile:
+			"../ABC/workflow/Snakefile"
+		config: get_abc_config(config)
 
-use rule * from ABC exclude all as abc_*
+	use rule * from ABC exclude all as abc_*
 
-BIOSAMPLE_DF = pd.read_csv(config["ABC_BIOSAMPLES"], sep="\t")
-BIOSAMPLES = BIOSAMPLE_DF["biosample"].to_list()
-BIOSAMPLE_ACTIVITES = {
-	biosample: activity for _, (biosample, activity) in 
-	BIOSAMPLE_DF[["biosample", "default_accessibility_feature"]].iterrows()
-}
+	# set/reset ABC_directory column
+	DATASET_DF['ABC_directory'] = RESULTS_DIR + DATASET_DF['biosample']
+	OUTPUT_FILES.extend(expand(os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "EnhancerPredictionsAllPutative.tsv.gz"), biosample=SAMPLES))
+
+	# set biosample column to be compatible with ABC?
+	DATASET_DF['biosample'] = DATASET_DF['dataset']
+
+if ("features_CRISPR" in STEPS):
+	OUTPUT_FILES.extend(expand(os.path.join(RESULTS_DIR, "{biosample}", "EPCrisprBenchmark_ensemble_data_GRCh38.K562_ActivityOnly_features_{nafill}.tsv.gz"), biosample=SAMPLES, nafill=["NAfilled", "withNA"]))
+
+if ("predict_genomewide" in STEPS): 
+	OUTPUT_FILES.extend(expand(os.path.join(RESULTS_DIR, "{biosample}", "encode_e2g_predictions.tsv.gz"), biosample=SAMPLES))
+	OUTPUT_FILES.extend(expand(os.path.join(RESULTS_DIR, "{biosample}", f"encode_e2g_predictions_threshold{threshold}.tsv.gz"), zip, biosample=SAMPLES, threshold=DATASET_DF['threshold'])) 
+	# these qc plots seem specific to the IGVF analysis and filename/script needs to be updated to take new config with threshold per dataset
+	# OUTPUT_FILES.extend(os.path.join(RESULTS_DIR, f"qc_plots_threshold{threshold}.pdf"))
 
 rule all:
 	input: 
-		expand(
-			os.path.join(RESULTS_DIR, "{biosample}", "encode_e2g_predictions.tsv.gz"), biosample=BIOSAMPLES
-		),
-		expand(
-			os.path.join(RESULTS_DIR, "{biosample}", f"encode_e2g_predictions_threshold{config['threshold']}.tsv.gz"), biosample=BIOSAMPLES
-		),
-		os.path.join(RESULTS_DIR, f"qc_plots_threshold{config['threshold']}.pdf"),
-		expand(
-			os.path.join(RESULTS_DIR, "{biosample}", "EPCrisprBenchmark_ensemble_data_GRCh38.K562_ActivityOnly_features_{nafill}.tsv.gz"), nafill = ["withNA", "NAfilled"], biosample=BIOSAMPLES
-		)
+		OUTPUT_FILES
 	
-
+## Generate features
 rule gen_new_features: 
 	input:
-		abc_predictions = os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "EnhancerPredictionsAllPutative.tsv.gz"),
-		enhancer_list = os.path.join(RESULTS_DIR, "{biosample}", "Neighborhoods", "EnhancerList.txt"),
+		abc_predictions = lambda wildcards: os.path.join(DATASET_DF.loc[wildcards.biosample, 'ABC_directory'], "Predictions", "EnhancerPredictionsAllPutative.tsv.gz"),
+		enhancer_list = lambda wildcards: os.path.join(DATASET_DF.loc[wildcards.biosample, 'ABC_directory'], "Neighborhoods", "EnhancerList.txt"),
 	params:
 		gene_TSS500 = config['gene_TSS500'],
 		chr_sizes = config['chr_sizes']
@@ -79,15 +92,13 @@ rule gen_new_features:
 # create activity-only feature table
 rule activity_only_features:
 	input:
-		feature_config = "config/feature_config.tsv",
-		abc = os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "EnhancerPredictionsAllPutative.tsv.gz"),
+		feature_config = lambda wildcards: DATASET_DF.loc[wildcards.biosample, 'feature_table'],
+		abc = lambda wildcards: os.path.join(DATASET_DF.loc[wildcards.biosample, 'ABC_directory'], "Predictions", "EnhancerPredictionsAllPutative.tsv.gz"),
 		NumCandidateEnhGene = os.path.join(RESULTS_DIR, "{biosample}", "NumCandidateEnhGene.tsv"),
 		NumTSSEnhGene = os.path.join(RESULTS_DIR, "{biosample}", "NumTSSEnhGene.tsv"),
 		NumEnhancersEG5kb = os.path.join(RESULTS_DIR, "{biosample}", "NumEnhancersEG5kb.txt"),
 		SumEnhancersEG5kb = os.path.join(RESULTS_DIR, "{biosample}", "SumEnhancersEG5kb.txt"),
 		ubiqExprGenes = config["ubiq_expr_genes"]
-	params:
-		activity = lambda wildcards: BIOSAMPLE_ACTIVITES[wildcards.biosample]
 	output: 
 		predictions_extended = os.path.join(RESULTS_DIR, "{biosample}", "ActivityOnly_features.tsv.gz")
 	conda:
@@ -102,13 +113,12 @@ rule overlap_activity_only_features_crispr:
 	input:
 		features = os.path.join(RESULTS_DIR, "{biosample}/ActivityOnly_features.tsv.gz"),
 		crispr = config['crispr_dataset'],
-		config = config['feature_config'],
+		config = lambda wildcards: DATASET_DF.loc[wildcards.biosample, 'feature_table'],
 		tss = config['gene_TSS500']
 	output: 
 		os.path.join(RESULTS_DIR, "{biosample}", "EPCrisprBenchmark_ensemble_data_GRCh38.K562_ActivityOnly_features_{nafill}.tsv.gz")
 	params:
 		filter_genes = "none",
-		activity = lambda wildcards: BIOSAMPLE_ACTIVITES[wildcards.biosample]
 	conda:
 		"envs/encode_e2g_features.yml" 
 	resources:
@@ -116,14 +126,14 @@ rule overlap_activity_only_features_crispr:
 	script:
 		"scripts/overlap_features_with_crispr_data.R"
 
-
+## Generate E2G predictions
 rule generate_e2g_predictions:
 	input:
 		predictions_extended = os.path.join(RESULTS_DIR, "{biosample}", "ActivityOnly_features.tsv.gz"),
+		trained_model = lambda wildcards: DATASET_DF.loc[wildcards.biosample, 'trained_model']
 	params:
-		feature_table_file = lambda wildcards: config["feature_table"][BIOSAMPLE_ACTIVITES[wildcards.biosample]],
-		epsilon = config["epsilon"],
-		models_dir = lambda wildcards: config["models_dir"][BIOSAMPLE_ACTIVITES[wildcards.biosample]]
+		feature_table_file = lambda wildcards: DATASET_DF.loc[wildcards.biosample, 'feature_table'],
+		epsilon = 0.01, # this should not be changed
 	conda:
 		"envs/encode_e2g_features.yml"
 	resources:
@@ -136,7 +146,7 @@ rule generate_e2g_predictions:
 			--predictions {input.predictions_extended} \
 			--feature_table_file {params.feature_table_file} \
 			--epsilon {params.epsilon} \
-			--models_dir {params.models_dir} \
+			--models_dir {input.trained_model} \
 			--output_file {output.prediction_file}
 		"""
 
@@ -144,7 +154,8 @@ rule filter_e2g_predictions:
 	input:
 		prediction_file = os.path.join(RESULTS_DIR, "{biosample}", "encode_e2g_predictions.tsv.gz")
 	params:
-		threshold = config["threshold"],
+		threshold = lambda wildcards: DATASET_DF.loc[wildcards.biosample, 'threshold'],
+		keep_self_promoters = True
 	conda:
 		"envs/encode_e2g_features.yml"
 	resources:
@@ -153,7 +164,11 @@ rule filter_e2g_predictions:
 		thresholded = os.path.join(RESULTS_DIR, "{biosample}", "encode_e2g_predictions_threshold{threshold}.tsv.gz")
 	shell:
 		"""
-		zcat {input.prediction_file} | awk -F'\t' '$NF >= {params.threshold}' | gzip > {output.thresholded}
+		python workflow/scripts/threshold_e2g_predictions.py \
+			--all_predictions_file {input.prediction_file} \
+			--threshold {params.threshold} \
+			--keep_self_promoters {params.keep_self_promoters} \
+			--output_file {output.thresholded}
 		"""
 
 rule get_stats:
@@ -170,21 +185,21 @@ rule get_stats:
 		python workflow/scripts/get_stats.py --predictions {input.thresholded} --output_file {output.stats}
 		"""
 
-rule generate_plots:
-	input:
-		expand(
-			os.path.join(RESULTS_DIR, "{biosample}", f"encode_e2g_predictions_threshold{config['threshold']}_stats.tsv"), biosample=BIOSAMPLES
-		)
-	conda:
-		"envs/encode_e2g_features.yml"
-	resources:
-		mem_mb=4*1000
-	output:
-		plots = os.path.join(RESULTS_DIR, "qc_plots_threshold{threshold}.pdf")
-	shell:
-		"""
-		python workflow/scripts/generate_plots.py \
-			--results_dir {RESULTS_DIR} \
-			--output_file {output.plots} \
-			# --y2ave_metadata /oak/stanford/groups/engreitz/Users/atan5133/igvf_dataset_processing/Y2AVE_SingleCellDatasets.CellClusterTable.tsv
-		"""
+# rule generate_plots:
+# 	input:
+# 		expand(
+# 			os.path.join(RESULTS_DIR, "{biosample}", f"encode_e2g_predictions_threshold{config['threshold']}_stats.tsv"), biosample=BIOSAMPLES
+# 		)
+# 	conda:
+# 		"envs/encode_e2g_features.yml"
+# 	resources:
+# 		mem_mb=4*1000
+# 	output:
+# 		plots = os.path.join(RESULTS_DIR, "qc_plots_threshold{threshold}.pdf")
+# 	shell:
+# 		"""
+# 		python workflow/scripts/generate_plots.py \
+# 			--results_dir {RESULTS_DIR} \
+# 			--output_file {output.plots} \
+# 			# --y2ave_metadata /oak/stanford/groups/engreitz/Users/atan5133/igvf_dataset_processing/Y2AVE_SingleCellDatasets.CellClusterTable.tsv
+# 		"""

--- a/workflow/scripts/gen_new_features.py
+++ b/workflow/scripts/gen_new_features.py
@@ -66,6 +66,7 @@ def determine_num_candidate_enh_gene(pred_df, results_dir):
         _populate_enhancer_count_from_tss(df, upstream_enh, is_upstream=True)
         _populate_enhancer_count_from_tss(df, downstream_enh, is_upstream=False)
 
+    df = df.fillna(value=0)
     df["NumCandidateEnhGene"] = df["NumCandidateEnhGene"].astype("int")
     df[["name", "TargetGene", "NumCandidateEnhGene"]].to_csv(
         os.path.join(results_dir, "NumCandidateEnhGene.tsv"),

--- a/workflow/scripts/get_fill_values.R
+++ b/workflow/scripts/get_fill_values.R
@@ -4,8 +4,8 @@ get_fill_values <- function(features, config) {
   
   # get fill values for each feature
   fill_values <- config %>% 
-    filter(output_col %in% colnames(features)) %>% 
-    select(output_col, fill_value) %>% 
+    filter(feature %in% colnames(features)) %>% 
+    select(feature, fill_value) %>% 
     distinct() %>% 
     deframe()
   

--- a/workflow/scripts/overlap_features_with_crispr_data.R
+++ b/workflow/scripts/overlap_features_with_crispr_data.R
@@ -1,8 +1,5 @@
 ## Overlap an E-G features table with CRISPR data
 
-# save.image("crispr.rda")
-# stop()
-
 # required packages
 suppressPackageStartupMessages({
   library(data.table)
@@ -91,13 +88,13 @@ crispr <- select(crispr, -c(pair_uid, merged_uid, merged_start, merged_end))
 
 # load feature config file and only retain entries for features in input data
 config <- fread(snakemake@input$config)
-config <- filter(config, output_col %in% colnames(features))
+config <- filter(config, feature %in% colnames(features))
 
 # load tss annotations
 tss <- fread(snakemake@input$tss, col.names = c("chr", "start", "end", "name", "score", "strand"))
 
 # create vector with aggregation functions for each feature
-agg_funs <- deframe(distinct(select(config, output_col, aggregate_function)))
+agg_funs <- deframe(distinct(select(config, feature, aggregate_function)))
 
 # filter out any CRISPR E-G pairs involving genes not part of the TSS universe or feature genes
 if (snakemake@params$filter_genes == "tss_universe") {
@@ -113,7 +110,7 @@ if (snakemake@params$filter_genes == "tss_universe") {
 # overlap feature table with CRISPR data
 output <- merge_feature_to_crispr(crispr,
   feature = features,
-  feature_score_cols = unique(config$output_col),
+  feature_score_cols = unique(config$feature),
   agg_fun = agg_funs, fill_value = NA_real_
 )
 

--- a/workflow/scripts/run_e2g.py
+++ b/workflow/scripts/run_e2g.py
@@ -7,44 +7,36 @@ import pandas as pd
 MODEL = "ENCODE-E2G"
 
 
-def make_e2g_predictions(df_enhancers, feature_list, models_dir, epsilon):
+def make_e2g_predictions(df_enhancers, feature_list, trained_model, epsilon):
     # transform the features
     X = df_enhancers.loc[:, feature_list]
     X.columns = feature_list
     X = np.log(np.abs(X) + epsilon)
-    chr_list = np.unique(df_enhancers["chr"])
 
-    for chr in chr_list:
-        idx_test = df_enhancers[df_enhancers["chr"] == chr].index.values
-
-        if len(idx_test) > 0:
-            X_test = X.loc[idx_test, :]
-
-            with open(f"{models_dir}/model_{MODEL}_test_{chr}.pkl", "rb") as f:
-                model = pickle.load(f)
-
-            probs = model.predict_proba(X_test)
-            df_enhancers.loc[idx_test, MODEL + ".Score"] = probs[:, 1]
+    with open(trained_model,'rb') as f:
+        model = pickle.load(f)
+    probs = model.predict_proba(X)
+    df_enhancers[MODEL+'.Score_full'] = probs[:, 1]
+            
     return df_enhancers
 
 
 @click.command()
 @click.option("--predictions", required=True)
 @click.option("--feature_table_file", required=True)
-@click.option("--models_dir", required=True)
+@click.option("--trained_model", required=True)
 @click.option("--epsilon", type=float, default=0.01)
 @click.option("--output_file", required=True)
-def main(predictions, feature_table_file, models_dir, epsilon, output_file):
+def main(predictions, feature_table_file, trained_model, epsilon, output_file):
     feature_table = pd.read_csv(feature_table_file, sep="\t")
-    feature_list = feature_table[feature_table[MODEL] == 1]["features"]
+    feature_list = feature_table["feature"]
 
     df_enhancers = pd.read_csv(predictions, sep="\t")
     df_enhancers = df_enhancers.replace([np.inf, -np.inf], np.nan)
     df_enhancers = df_enhancers.fillna(0)
 
-    df_enhancers = make_e2g_predictions(df_enhancers, feature_list, models_dir, epsilon)
+    df_enhancers = make_e2g_predictions(df_enhancers, feature_list, trained_model, epsilon)
     df_enhancers.to_csv(output_file, compression="gzip", sep="\t", index=False)
-
 
 if __name__ == "__main__":
     main()

--- a/workflow/scripts/threshold_e2g_predictions.py
+++ b/workflow/scripts/threshold_e2g_predictions.py
@@ -1,0 +1,37 @@
+import pickle
+
+import click
+import numpy as np
+import pandas as pd
+
+MODEL = "ENCODE-E2G"
+
+
+def threshold_predictions(all_putative, threshold, keep_self_promoters):
+    # filter by threshold and promoter category
+    filtered_predictions = all_putative[all_putative['ENCODE-E2G.Score'] >= threshold]
+
+    # process promoters & self-promoters
+    if keep_self_promoters:
+        return filtered_predictions[(filtered_predictions["class"] != "promoter") | filtered_predictions["isSelfPromoter"]]
+    else:
+        return filtered_predictions[filtered_predictions["class"] != "promoter"]
+            
+    return filtered_predictions
+
+
+@click.command()
+@click.option("--all_predictions_file", required=True)
+@click.option("--threshold", required=True)
+@click.option("--keep_self_promoters", type=bool, default=True)
+@click.option("--output_file", required=True)
+
+def main(all_predictions_file, threshold, keep_self_promoters, output_file):
+    all_predictions = pd.read_csv(all_predictions_file, sep="\t")
+
+    filtered_predictions = threshold_predictions(all_predictions, threshold, keep_self_promoters)
+
+    filtered_predictions.to_csv(output_file, compression="gzip", sep="\t", index=False)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Goals:
- Support different goals for running the pipeline: always generate features on all candidate elements; optionally generate features on K562 CRISPR dataset from ABC directory, optionally run ABC and generate features, optionally predict genome-wide given a pre-trained model
- Simplify feature table format, also compatible with ENCODE-E2G pipeline
- Update config format to be flexible for these options
- Edit thresholding of genome-wide predictions to filter out distal promoters
- Edit genome-wide prediction function to use aggregate model instead of per-chromosome models

@atancoder Could you help review this, particularly the "run_ABC" option? I don't really understand how the modules work. 