### PR TITLE
fix bugs that prevented snakemake from running

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -42,7 +42,7 @@ BIOSAMPLE_ACTIVITES = {
 }
 # make directory of ABC output where EnhancersAllPutative and EnhancerList are found
 # defined to be compatible with training workflow, which can start from an existing ABC directory
-ABC_BIOSAMPLES_DIR = {biosample: os.path.join(RESULTS_DIR, biosample) for biosample in BIOSAMPLE_DF.biosamples}
+ABC_BIOSAMPLES_DIR = {biosample: os.path.join(RESULTS_DIR, biosample) for biosample in BIOSAMPLE_DF.biosample}
 
 # These rules requires the variables above to be defined
 include: "rules/gen_new_features.smk"
@@ -55,5 +55,5 @@ rule all:
 		expand(
 			os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "encode_e2g_predictions.tsv.gz"), biosample=BIOSAMPLES
 		),
-		[os.path.join(RESULTS_DIR, f"{biosample}", "Metrics", f"encode_e2g_predictions_threshold{get_threshold(biosample)}_stats.tsv") for biosample in BIOSAMPLES]
+		[os.path.join(RESULTS_DIR, f"{biosample}", "Metrics", f"encode_e2g_predictions_threshold{get_threshold(biosample)}_stats.tsv") for biosample in BIOSAMPLES],
 		plots = os.path.join(RESULTS_DIR, "qc_plots.pdf")


### PR DESCRIPTION
Missing a comma and there was an invalid reference to `biosamples` column

## Test Plan

`snakemake -n -p` works

`snakemake -j1 --use-conda` works against chr22