### PR TITLE
Improve runtime and memory efficiency of generate_num_tss_enh_gene

### DIFF
--- a/workflow/rules/genomewide_features.smk
+++ b/workflow/rules/genomewide_features.smk
@@ -96,15 +96,13 @@ rule generate_num_tss_enh_gene:
 		mem_mb=partial(ABC.determine_mem_mb, min_gb=32)
 	output:
 		numTSSEnhGene = os.path.join(RESULTS_DIR, "{biosample}", "new_features", "NumTSSEnhGene.tsv"),
-		extendedEnhancerRegions = temp(os.path.join(RESULTS_DIR, "{biosample}",  "new_features", "extendedEnhancerRegions.txt")),
-		enhancerTSSInt = temp(os.path.join(RESULTS_DIR, "{biosample}", "new_features", "extendedEnhancerRegions_TSS_int.tsv.gz"))
+		extendedEnhancerRegions = temp(os.path.join(RESULTS_DIR, "{biosample}",  "new_features", "extendedEnhancerRegions.txt"))
 	shell: 
 		""" 
 		python {params.scripts_dir}/feature_tables/gen_num_tss_enh_gene.py \
 			--abc_predictions {input.abc_predictions} \
 			--ref_gene_tss {params.gene_TSS500} \
 			--extended_enhancers {output.extendedEnhancerRegions} \
-			--enhancer_tss_int {output.enhancerTSSInt} \
 			--out_file {output.numTSSEnhGene}
 		"""
 

--- a/workflow/scripts/feature_tables/gen_num_tss_enh_gene.py
+++ b/workflow/scripts/feature_tables/gen_num_tss_enh_gene.py
@@ -24,25 +24,16 @@ def determine_num_tss_enh_gene(
         extended_enhancers, sep="\t", index=False
     )
 
-    #  Intersect midpoint of enhancer to target gene regions with TSSs (includes overlap with target gene)
-    os.system(
-        "sed '1d' {} | bedtools intersect -a stdin -b {} -wa -wb | cut -f4,5 | pigz > {}".format(
-            extended_enhancers, ref_gene_tss, enhancer_tss_int
-        )
-    )
-    print("Reading in {}".format(enhancer_tss_int))
-    predictions = pd.read_csv(enhancer_tss_int, sep="\t", names=["class", "gene"])
+    # bedtools intersects extended enhancers with reference TSS and counts overlaps
+    header = "name\tgene\tcount\n"
+    cmd = f"""
+        printf "{header}" > {out_file};
+        bedtools intersect -a {extended_enhancers} -b {ref_gene_tss} -wa -c \
+        | cut -f4,5,6 \
+        >> {out_file}
+    """
+    os.system(cmd)
 
-    # Calculate the number of TSS regions that fall within the enhancer to target gene regions.
-    num_tss_between_enh_and_gene = (
-        predictions.groupby(["class", "gene"]).size().reset_index()
-    )
-
-    num_tss_between_enh_and_gene.to_csv(
-        out_file,
-        sep="\t",
-        index=False,
-    )
     print("Saved num TSS between enh and gene")
 
 


### PR DESCRIPTION
Using bedtools native counting capability rather than loading all overlaps into pandas reduces RAM usage to 1/6th of prior and allows this rule to run nearly 10x faster.  