### PR TITLE
Add jq dependency to encode_re2g conda env

### DIFF
--- a/workflow/envs/encode_re2g.yml
+++ b/workflow/envs/encode_re2g.yml
@@ -12,6 +12,7 @@ dependencies:
   - ucsc-bedgraphtobigwig
   - csvtk
   - gzip
+  - jq
   - numpy
   - pandas
   - pyarrow


### PR DESCRIPTION
Addresses CircleCI failure as of July 4, 2026.  The bioconductor-genomeinfodbdata post-link script (pulled in via bioconductor-genomicranges) shells out to yq, which requires jq on PATH. It only worked before because jq happened to be present in whatever base image/host was running mamba env create.