### PR TITLE
Install jq via apt so bioconductor-genomeinfodbdata post-link script succeeds in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run: git submodule update --init
       - run:
           name: Install basic OS pkgs
-          command: apt-get update && apt-get -y install curl vim
+          command: apt-get update && apt-get -y install curl vim jq
       - run:
           name: Run Linter (python black)
           command: |


### PR DESCRIPTION
Touches CircleCI config ONLY, not the ENCODE-rE2G conda env

bioconductor-genomeinfodbdata's post-link script shells out to yq, which requires jq on PATH. It only worked before because jq happened to be present in whatever base image/host was running mamba env create; the condaforge/mambaforge CircleCI image no longer has it. Install it as an OS package instead of modifying the conda env.