### PR TITLE
Revert conda env jq dependency; install via CircleCI OS pkgs instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run: git submodule update --init
       - run:
           name: Install basic OS pkgs
-          command: apt-get update && apt-get -y install curl vim
+          command: apt-get update && apt-get -y install curl vim jq
       # - run:
       #     name: Run Linter (python black)
       #     command: |

--- a/workflow/envs/encode_re2g.yml
+++ b/workflow/envs/encode_re2g.yml
@@ -12,7 +12,6 @@ dependencies:
   - ucsc-bedgraphtobigwig
   - csvtk
   - gzip
-  - jq
   - numpy
   - pandas
   - pyarrow


### PR DESCRIPTION
PR #101 added jq to encode_re2g.yml, but Maya's existing Singularity containers built from this env file may rely on its exact content hash, and changing the pinned conda env risks disrupting that reproducibility. Revert the conda env change and instead install jq as an OS package in CircleCI, matching the approach used to fix ENCODE_rE2G:main. bioconductor-genomeinfodbdata's post-link script just needs jq resolvable on PATH -- it doesn't care how it got there, and jq is never invoked during actual pipeline rule execution.