### PR TITLE
Bump Run tests no_output_timeout to 40m, matching main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             mamba env create -f workflow/envs/encode_re2g.yml
       - run:
           name: Run tests
-          no_output_timeout: 30m
+          no_output_timeout: 40m
           command: |
             conda run -n encode_re2g pytest -s -n 4 tests/
 


### PR DESCRIPTION
dev has run this step at 30m while main has run at 40m for a while. Match main's buffer so dev isn't more exposed to CI timeouts from slower-than-usual bioconda solves.